### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_unapi/views.py
+++ b/invenio_unapi/views.py
@@ -22,7 +22,7 @@
 from flask import (Blueprint, make_response, redirect, render_template,
                    request, url_for)
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio_formatter.registry import output_formats
 
 from six import iteritems

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,9 +21,6 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-base>=0.2.1',
     'invenio-formatter>=0.2.0',
 ]
 
@@ -50,6 +51,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
- FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
