### PR TITLE
tests: fix incompatibility with pytest>=2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel"
+  - "travis_retry pip install check-manifest mock twine wheel"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -62,6 +62,7 @@ before_script:
   - "inveniomanage database create --quiet || echo ':('"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_unapi --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_unapi --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -24,3 +24,5 @@
 
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
+-e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
+

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ requirements = [
 test_requirements = [
     'unittest2>=1.1.0',
     'Flask_Testing>=0.4.1',
-    'pytest>=2.7.0',
-    'pytest-cov>=1.8.0',
+    'pytest>=2.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'coverage>=3.7.1',
+    'coverage>=4.0.0',
 ]
 
 
@@ -78,9 +78,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
-    'invenio-base>=0.2.1',
+    'invenio-base>=0.3.0',
     'invenio-formatter>=0.2.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ test_requirements = [
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
     'coverage>=4.0.0',
+    'invenio-testing>=0.1.0',
 ]
 
 

--- a/tests/test_unapi.py
+++ b/tests/test_unapi.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 
 from flask import url_for
 
-from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+from invenio_testing import InvenioTestCase
 
 
 class UnAPIMixin(InvenioTestCase):
@@ -53,8 +53,3 @@ class TestUnAPIEndpoint(UnAPIMixin):
         response = self.client.get(
             url_for('unapi.index', id=1, format='marcxml'))
         assert response.status_code == 302
-
-TEST_SUITE = make_test_suite(TestUnAPIEndpoint)
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
- FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
