### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -34,8 +34,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-UnAPI.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-unapi
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     keywords='invenio TODO',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-unapi',
     packages=[
         'invenio_unapi',


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
